### PR TITLE
handle initial file gen and fix day0 season

### DIFF
--- a/Location.py
+++ b/Location.py
@@ -33,7 +33,7 @@ class Location():
         if daysplayed != 0:
             season = (daysplayed-1) // 28 % 4
         else:
-            season = 1
+            season = 0
         rand = CSRandomLite(int(seed // 2) +daysplayed)
         num1 = rand.Next(1, min(5, 7 - itemsLength))
         for index1 in range(num1):
@@ -82,7 +82,9 @@ class Location():
 
     def processDay(self,seed,daysplayed):
         self.items.clear();
-
+        if daysplayed < 7:
+            # GameLocation.loadObjects() (called by GameLocation::ctor)
+            self.calculateSpawns(seed, 0)
         dayOfMonth = ((daysplayed-1) % 28) + 1;
         day = dayOfMonth % 7;
         for dayOfWeek in range(day+1):


### PR DESCRIPTION
I originally thought it was a layering thing when trying to predict beach forage but realized it was just it didn't call the extra day0 spawn/the season was incorrect.

Easy test is seed: 888011632 on day 5 beach
Actual:
`{(52, 15): 'Mussel', (67, 7): 'Oyster', (14, 14): 'Clam', (28, 15): 'Oyster', (25, 8): 'Cockle', (79, 8): 'Oyster'}`

Old:
`{(28, 15): 'Oyster', (25, 8): 'Cockle', (39, 12): 'Clam', (79, 8): 'Oyster'}`